### PR TITLE
fixing q=0 case with different polynomial routine

### DIFF
--- a/arfit/kalman.py
+++ b/arfit/kalman.py
@@ -39,7 +39,7 @@ def kalman_prediction_and_variance(ts, ys, dys, mu, sigma, ar_roots, ma_roots):
     p = ar_roots.shape[0]
     q = ma_roots.shape[0]
 
-    ma_poly = np.poly(ma_roots)
+    ma_poly = np.polynomial.polynomial.polyfromroots(ma_roots)
     ma_poly = ma_poly / ma_poly[-1] # Has a 1 in the constant term
     ma_poly = ma_poly[::-1] # 1.0 + c[1]*x + c[2]*x^2 + ...
     ma_poly = np.concatenate((ma_poly,np.zeros(p-q-1)))


### PR DESCRIPTION
np.poly returns a float for the case of an empty array. np.polynomial.polynomial.polyfromroots returns a 1d array of length 1, so we can access the -1th element
